### PR TITLE
Switch to bigtiff for LONG8 and SLONG8 datatypes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,107 @@ Pure Python tools for reading and writing all TIFF IFDs, sub-IFDs, and tags.
 
 Developed by Kitware, Inc. with funding from The National Cancer Institute.
 
+Example
+=======
+
+.. code-block:: python
+    import tifftools
+    info = tifftools.read_tiff('photograph.tif')
+    info['ifds'][0]['tags'][tifftools.Tag.ImageDescription.value] = {
+        'data': 'A dog digging.',
+        'datatype': tifftools.Datatype.ASCII
+    }
+    exififd = info['ifds'][0]['tags'][tifftools.Tag.EXIFIFD.value]['ifds'][0]
+    exififd['tags'][tifftools.constants.EXIFTag.FNumber.value] = {
+        'data': [54, 10],
+        'datatype': tifftools.Datatype.RATIONAL
+    }
+    tifftools.write_tiff(info, 'photograph_tagged.tif')
+
+Purpose
+=======
+
+tifftools provides a library and a command line program for maniplulating TIFF files.  It can split multiple images apart, merge images together, set any tag in any IFD, and dump all IFDs and tags in a single command.  It only uses python standard library modules, and is therefore widely compatible.
+
+Rationale
+---------
+
+There was a need to combine images from multiple TIFF files without altering the image data or losing any tag information.  Further, when changing tag values, it was essential that the old values were fully removed from the output.
+
+The command line tools associated with libtiff are commonly used for similar purposes.  The libtiff command tools have significant limitations: ``tiffdump`` and ``tiffinfo`` require multiple commands to see information from all IFDs.  ``tiffset`` does not remove data from a file; rather it appends to the file to only reference new data, leaving the old values inside the file.  ``tiffsplit`` doesn't keep tags it doesn't recognize, loosing data.  ``tiffcp`` always reencodes images and will fail for compression types it does not know.
+
+Likewise, there is a wide variety of EXIF tools.  For the most part, these only alter tags, usually by appending to the existing file.
+
+Many programs deal with both classic and BigTIFF.  Some will start writing a classic TIFF, but leave a small amount of unused space just after the file header.  If the file exceeds 4Gb, parts of the file are rewritten to covert it to a BigTIFF file, leaving small amounts of abandoned data within the file.
+
+``tifftools`` fills this need.  All tags are copied, even if unknown.  Files are always rewritten so that there is never abandoned data inside the file.  ``tifftools dump`` shows information on all IFDs and tags.  Many of the command line options are directly inspired from libtiff.
+
+``tifftools`` does NOT compress or decompress any image data.  This is not an image viewer.  If you need to recompress an image or otherwise manipulate pixel data, use libtiff or another library.
+
+Commands
+========
+
+- tiff_split
+
+- tiff_concat
+
+- tiff_dump
+
+- tiff_set
+
+Library Functions
+=================
+
+- read_tiff
+
+- write_tiff
+
+- Constants
+
+- Tag
+
+- Datatype
+
+- get_or_create_tag
+
+- EXIFTag, GPSTag, etc.
+
+TIFF File Structure
+===================
+
+TIFF Files consist of one or more IFDs (Image File Directories).  These can
+be located anywhere within the file, and are referenced by their absolute
+position within the file.  IFDs can refer to image data but they can also
+contain a collection of metadata (for instance, EXIF or GPS data).  Small
+data values are stored directly in the IFD.  Bigger data values (such as
+image data, longer string, or lists of numbers) are referenced by the IFD and
+are stored elsewhere in the file.
+
+In the simple case, a TIFF file may have a list of IFDs, each one referencing
+the next.  However, a complex TIFF file, such as those used by some
+Whole-Slide Image (WSI) microscopy systems, can have IFDs organized in a
+branching structure, where some IFDs are in a list and some reference SubIFDs
+with additional images.
+
+TIFF files can have their primary data stored in either little-endian or
+big-endian.  Offsets to data are store as absolute numbers inside a TIFF
+file.  There are two variations: "classic" and "BigTIFF" which use 32-bits
+and 64-bits for these offsets, respectively.  If the file size exceeds 4 Gb or
+uses 64-bit integer datatypes, it must be written as a BigTIFF.
+
+Limitations
+===========
+
+Unknown tags that are offsets and have a datatype other than IFD or IFD8
+won't be copied properly, as it is impossible to distinguish integer data
+from offsets given LONG or LONG8 datatypes.  This can be remedied by
+defining a new ``TiffConstant`` record which contains a ``bytecounts`` entry
+to instruct whether the offsets refere to fixed length data or should get the
+length of data from another tag.
+
+Because files are ALWAYS rewritten, ``tifftools`` is slower than libtiff's ``tiffset`` and most EXIF tools.
+
+
 .. |build-status| image:: https://circleci.com/gh/DigitalSlideArchive/tifftools.png?style=shield
     :target: https://circleci.com/gh/DigitalSlideArchive/tifftools
     :alt: Build Status

--- a/tests/test_write_tiff.py
+++ b/tests/test_write_tiff.py
@@ -43,6 +43,38 @@ def test_write_switch_to_bigtiff(tmp_path):
     assert destinfo['bigtiff'] is True
 
 
+def test_write_bigtiff_from_datatype(tmp_path):
+    path = os.path.join(os.path.dirname(__file__), 'data', 'good_single.tif')
+    info = tifftools.read_tiff(path)
+    info['ifds'][0]['tags'][23456] = {
+        'datatype': tifftools.Datatype.LONG8,
+        'data': [8],
+    }
+    destpath = tmp_path / 'sample.tiff'
+    tifftools.write_tiff(info, destpath)
+    destinfo = tifftools.read_tiff(destpath)
+    assert destinfo['bigtiff'] is True
+
+
+def test_write_bigtiff_with_long_data(tmp_path):
+    path = datastore.fetch('hamamatsu.ndpi')
+    info = tifftools.read_tiff(path)
+    info['ifds'][0]['tags'][tifftools.Tag.FreeOffsets.value] = {
+        'datatype': tifftools.Datatype.LONG,
+        'data': [8],
+    }
+    info['ifds'][0]['tags'][tifftools.Tag.FreeByteCounts.value] = {
+        'datatype': tifftools.Datatype.LONG,
+        'data': [97044000],
+    }
+    info['ifds'].extend(info['ifds'])
+    info['ifds'].extend(info['ifds'])
+    destpath = tmp_path / 'sample.tiff'
+    tifftools.write_tiff(info, destpath)
+    destinfo = tifftools.read_tiff(destpath)
+    assert destinfo['bigtiff'] is True
+
+
 def test_write_bytecount_data(tmp_path):
     path = os.path.join(os.path.dirname(__file__), 'data', 'good_single.tif')
     info = tifftools.read_tiff(path)

--- a/tifftools/__init__.py
+++ b/tifftools/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 from .commands import main, tiff_concat, tiff_dump, tiff_info, tiff_merge, tiff_set, tiff_split
 from .constants import Datatype, Tag, TiffDatatype, TiffTag
+from .exceptions import MustBeBigTiffException, TifftoolsException, UnknownTagException
 from .tifftools import read_tiff, write_tiff
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,10 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 __all__ = (
     'Datatype', 'TiffDatatype',
     'Tag', 'TiffTag',
+
+    'TifftoolsException',
+    'UnknownTagException',
+    'MustBeBigTiffException',
 
     'read_tiff',
     'write_tiff',

--- a/tifftools/commands.py
+++ b/tifftools/commands.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 
 from .constants import Datatype, Tag, get_or_create_tag
+from .exceptions import TifftoolsException
 from .tifftools import read_tiff, read_tiff_limit_ifds, write_tiff
 
 logger = logging.getLogger(__name__)
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class ThrowOnLevelHandler(logging.NullHandler):
     def handle(self, record):
-        raise Exception(record.getMessage())
+        raise TifftoolsException(record.getMessage())
 
 
 def _apply_flags_to_ifd(ifd, bigtiff=None, bigendian=None, **kwargs):
@@ -226,7 +227,7 @@ def tiff_split(source, prefix=None, subifds=False, overwrite=False, **kwargs):
         for idx in range(numOutput):
             outputPath = _make_split_name(prefix, idx, neededChars)
             if os.path.exists(outputPath):
-                raise Exception('File already exists: %s' % outputPath)
+                raise TifftoolsException('File already exists: %s' % outputPath)
     for idx, ifd in enumerate(_iterate_ifds(info['ifds'], subifds=subifds)):
         outputPath = _make_split_name(prefix, idx, neededChars)
         if subifds and int(Tag.SubIFD) in ifd['tags']:
@@ -328,10 +329,11 @@ def _tagspec_to_ifd(tagspec, info, value=None):
     if ':' in tagspec:
         tagspec, datatype = tagspec.split(':', 1)
         if datatype not in Datatype:
-            raise Exception('Unknown datatype %s' % datatype)
+            raise TifftoolsException('Unknown datatype %s' % datatype)
         datatype = Datatype[datatype]
         if value is not None and datatype not in valueTypes:
-            raise Exception('Value %r cannot be converted to datatype %s' % (value, datatype))
+            raise TifftoolsException(
+                'Value %r cannot be converted to datatype %s' % (value, datatype))
     tag = get_or_create_tag(tagspec, tagSet, **({'datatype': datatype} if datatype else {}))
     if 'datatype' in tag:
         tagDatatypes = tag.datatype if isinstance(tag.datatype, tuple) else (tag.datatype, )
@@ -428,7 +430,7 @@ def tiff_set(source, output=None, overwrite=False, setlist=None, unset=None,
     if output is None:
         output = source
     if os.path.exists(output) and not overwrite:
-        raise Exception('File already exists: %s' % output)
+        raise TifftoolsException('File already exists: %s' % output)
     if os.path.realpath(source) == os.path.realpath(output) and source != '-':
         with tempfile.TemporaryDirectory('tifftools') as tmpdir:
             output = os.path.join(tmpdir, 'output.tiff')

--- a/tifftools/constants.py
+++ b/tifftools/constants.py
@@ -1,6 +1,8 @@
 # flake8: noqa 501
 # Disable flake8 line-length check (E501), it makes this file harder to read
 
+from .exceptions import UnknownTagException
+
 
 class TiffConstant(int):
     def __new__(cls, value, *args, **kwargs):
@@ -165,7 +167,7 @@ def get_or_create_tag(key, tagSet=None, upperLimit=True, **tagOptions):
     if tagSet and value in tagSet:
         return tagSet[value]
     if value < 0 or (upperLimit and value >= 65536):
-        raise Exception('Unknown tag %s' % key)
+        raise UnknownTagException('Unknown tag %s' % key)
     tagClass = tagSet._setClass if tagSet else TiffConstant
     return tagClass(value, tagOptions)
 

--- a/tifftools/exceptions.py
+++ b/tifftools/exceptions.py
@@ -1,0 +1,10 @@
+class TifftoolsException(Exception):
+    pass
+
+
+class UnknownTagException(TifftoolsException):
+    pass
+
+
+class MustBeBigTiffException(TifftoolsException):
+    pass

--- a/tifftools/path_or_fobj.py
+++ b/tifftools/path_or_fobj.py
@@ -36,7 +36,8 @@ def OpenPathOrFobj(pathOrObj, mode='rb'):
     if not is_filelike_object(pathOrObj):
         with open(pathOrObj, mode) as fobj:
             yield fobj
-    elif hasattr(pathOrObj, 'seekable') and pathOrObj.seekable() and hasattr(pathOrObj, 'tell'):
+    elif (hasattr(pathOrObj, 'seekable') and pathOrObj.seekable() and
+            hasattr(pathOrObj, 'tell') and hasattr(pathOrObj, 'truncate')):
         yield pathOrObj
     elif 'w' not in mode.lower():
         # This doesn't use the TemporaryFile context manager, as it is useful

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38}
+  test-py{36,37,38}
   flake8
 
 [testenv]


### PR DESCRIPTION
Use tifftools-specific exceptions.

Improve README.