### PR TITLE
Allow dumping multiple files in one command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ Commands
 
 - ``tifftools split [--subifds] [--overwrite] source [prefix]``: split a tiff file into separate files.  This is also available as the library function ``tifftools.tiff_split``.
 
-- ``tifftools concat [--overwrite] output source [source ...]``: merge multiple tiff files together.  Alias: ``tifftools merge``.  This is also available as the library function ``tifftools.tiff_concat``.
+- ``tifftools concat [--overwrite] source [source ...] output``: merge multiple tiff files together.  Alias: ``tifftools merge``.  This is also available as the library function ``tifftools.tiff_concat``.
 
-- ``tifftools dump [--max MAX] [--json] source``: print information about a tiff file, including all tags, IFDs, and subIFDs.  Alias: ``tifftool info``.  This is also available as the library function ``tifftools.tiff_dump``.
+- ``tifftools dump [--max MAX] [--json] source [source ...]``: print information about a tiff file, including all tags, IFDs, and subIFDs.  Alias: ``tifftool info``.  This is also available as the library function ``tifftools.tiff_dump``.
 
 - ``tifftools set source [--overwrite] [output] [--set TAG[:DATATYPE][,<IFD-#>] VALUE] [--unset TAG:[,<IFD-#>]] [--setfrom TAG[,<IFD-#>] TIFFPATH]``: modify, add, or remove tags.  This is also available as the library function ``tifftools.tiff_set``.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def prerelease_local_scheme(version):
 
 setup(
     name='tifftools',
-    use_scm_version={'local_scheme': prerelease_local_scheme},
+    use_scm_version={'local_scheme': prerelease_local_scheme, 'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -77,3 +77,22 @@ def test_tiff_dump_specific_ifd(suffix, num_ifds, capsys):
     tifftools.tiff_dump(path + suffix)
     captured = capsys.readouterr()
     assert len(captured.out.split('Directory ')) == num_ifds + 1
+
+
+def test_tiff_dump_multiple(capsys):
+    path1 = datastore.fetch('d043-200.tif')
+    path2 = datastore.fetch('subsubifds.tif')
+    tifftools.tiff_dump([path1, path2])
+    captured = capsys.readouterr()
+    assert len(captured.out.split('Directory ')) == 4 + 9 + 1
+
+
+def test_tiff_dump_multiple_json(capsys):
+    path1 = datastore.fetch('d043-200.tif')
+    path2 = datastore.fetch('subsubifds.tif')
+    tifftools.tiff_dump([path1, path2], json=True)
+    captured = capsys.readouterr()
+    info = json.loads(captured.out)
+    assert path1 in info
+    assert path2 in info
+    assert 'ifds' in info[path1]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -10,7 +10,7 @@ from .datastore import datastore
 def test_bigtiff_bigendian(tmp_path, bigtiff, bigendian):
     path = datastore.fetch('d043-200.tif')
     dest = tmp_path / 'results.tif'
-    cmd = ['merge', str(dest), path]
+    cmd = ['merge', path, str(dest)]
     cmd.extend(bigtiff)
     cmd.extend(bigendian)
     tifftools.main(cmd)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -44,11 +44,11 @@ def test_split_sub_subifds(tmp_path):
 def test_split_and_merge(test_path, tmp_path):
     path = datastore.fetch(test_path)
     destpath1 = tmp_path / ('initial' + os.path.splitext(test_path)[1])
-    tifftools.tiff_concat(destpath1, [path])
+    tifftools.tiff_concat([path], destpath1)
     tifftools.tiff_split(path, tmp_path / 'test')
     components = sorted([tmp_path / p for p in os.listdir(tmp_path) if p.startswith('test')])
     destpath2 = tmp_path / ('merged' + os.path.splitext(test_path)[1])
-    tifftools.tiff_merge(destpath2, components)
+    tifftools.tiff_merge(components, destpath2)
     chunksize = 1024 ** 2
     with open(destpath1, 'rb') as f1, open(destpath2, 'rb') as f2:
         while True:
@@ -62,13 +62,13 @@ def test_split_and_merge(test_path, tmp_path):
 def test_split_and_merge_by_ifd(tmp_path):
     path = datastore.fetch('sample.subifd.ome.tif')
     destpath1 = tmp_path / 'initial.tif'
-    tifftools.tiff_merge(destpath1, [path])
+    tifftools.tiff_merge([path], destpath1)
     tifftools.tiff_split(str(path) + ',0', tmp_path / 'test1')
     tifftools.tiff_split(str(path) + ',1', tmp_path / 'test2')
     tifftools.tiff_split(str(path) + ',2', tmp_path / 'test3')
     components = sorted([tmp_path / p for p in os.listdir(tmp_path) if p.startswith('test')])
     destpath2 = tmp_path / 'merged.tif'
-    tifftools.tiff_concat(destpath2, components)
+    tifftools.tiff_concat(components, destpath2)
     chunksize = 1024 ** 2
     with open(destpath1, 'rb') as f1, open(destpath2, 'rb') as f2:
         while True:

--- a/tifftools/__init__.py
+++ b/tifftools/__init__.py
@@ -1,17 +1,13 @@
 import logging
 
-from pkg_resources import DistributionNotFound, get_distribution
+from pkg_resources import get_distribution
 
 from .commands import main, tiff_concat, tiff_dump, tiff_info, tiff_merge, tiff_set, tiff_split
 from .constants import Datatype, Tag, TiffDatatype, TiffTag
 from .exceptions import MustBeBigTiffException, TifftoolsException, UnknownTagException
 from .tifftools import read_tiff, write_tiff
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = 'development'
+__version__ = get_distribution(__name__).version
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Switch destination and source parameters in the concat/merge command so that source is first, matching other commands.