### PR TITLE
Fix a bug that could occur when merging multiple tiff files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Version 1.2.4
+
+### Bug fixes
+- Fix checking offsets in merging multiple files (#49)
+
 ## Version 1.2.3
 
 ### Improvements

--- a/tifftools/tifftools.py
+++ b/tifftools/tifftools.py
@@ -454,7 +454,7 @@ def write_tag_data(dest, src, offsets, lengths, srclen):
             # read call
             while (olidx + 1 < len(offsetList) and
                    offsetList[olidx + 1][0] == offsetList[olidx][0] + lengths[idx] and
-                   check_offset(srclen, destOffsets[idx] + lengths[idx],
+                   check_offset(srclen, offsetList[olidx + 1][0],
                                 lengths[offsetList[olidx + 1][1]])):
                 destOffsets[offsetList[olidx + 1][1]] = destOffsets[idx] + lengths[idx]
                 olidx += 1


### PR DESCRIPTION
Specifically, the check if the offset within the source file was within bounds could be wrong.