### PR TITLE
Output values on word boundaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 1.2.6
+
+### Improvements
+- Align IFD values word boundaries (#54)
+- Output small tiffs in more cases (#53)
+
 ## Version 1.2.5
 
 ### Improvements

--- a/tifftools/tifftools.py
+++ b/tifftools/tifftools.py
@@ -349,6 +349,7 @@ def write_ifd(dest, bom, bigtiff, ifd, ifdPtr, tagSet=Tag):
                         'The file is large enough it must be in bigtiff format.')
                 taginfo = taginfo.copy()
                 taginfo['datatype'] = Datatype.LONG8 if bigtiff else Datatype.LONG
+
             if not bigtiff and Datatype[taginfo['datatype']] in {Datatype.LONG8, Datatype.SLONG8}:
                 raise MustBeBigTiffException('There are datatypes that require bigtiff format.')
             if Datatype[taginfo['datatype']].pack:
@@ -367,6 +368,9 @@ def write_ifd(dest, bom, bigtiff, ifd, ifdPtr, tagSet=Tag):
                     subifdPtrs[tag] = -(len(ifdrecord) + len(tagrecord))
                 tagrecord += data + b'\x00' * (tagdatalen - len(data))
             else:
+                # word alignment
+                if dest.tell() % 2:
+                    dest.write(b'\x00')
                 if tag.isIFD() or taginfo.get('datatype') in (Datatype.IFD, Datatype.IFD8):
                     subifdPtrs[tag] = dest.tell()
                 if not bigtiff and dest.tell() >= ptrmax:

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
 max-line-length = 100
 show-source = True
 format = pylint
-max-complexity = 15
+max-complexity = 18
 exclude =
   .eggs,
   .git,


### PR DESCRIPTION
Better handle saving to small tiff.  Before, once written to a bigtiff, it was unlikely to convert back to a small tiff since some fields written as LONG8 didn't automatically convert to LONG.