### PR TITLE
Rename Exceptions to Errors.

### DIFF
--- a/tifftools/__init__.py
+++ b/tifftools/__init__.py
@@ -4,7 +4,8 @@ from pkg_resources import get_distribution
 
 from .commands import main, tiff_concat, tiff_dump, tiff_info, tiff_merge, tiff_set, tiff_split
 from .constants import Datatype, Tag, TiffDatatype, TiffTag
-from .exceptions import MustBeBigTiffException, TifftoolsException, UnknownTagException
+from .exceptions import (MustBeBigTiffError, MustBeBigTiffException, TifftoolsError,
+                         TifftoolsException, UnknownTagError, UnknownTagException)
 from .tifftools import read_tiff, write_tiff
 
 __version__ = get_distribution(__name__).version
@@ -19,6 +20,9 @@ __all__ = (
     'Datatype', 'TiffDatatype',
     'Tag', 'TiffTag',
 
+    'TifftoolsError',
+    'UnknownTagError',
+    'MustBeBigTiffError',
     'TifftoolsException',
     'UnknownTagException',
     'MustBeBigTiffException',

--- a/tifftools/constants.py
+++ b/tifftools/constants.py
@@ -3,7 +3,7 @@
 
 import struct
 
-from .exceptions import UnknownTagException
+from .exceptions import UnknownTagError
 
 
 class TiffConstant(int):
@@ -166,7 +166,7 @@ def get_or_create_tag(key, tagSet=None, upperLimit=True, **tagOptions):
     if tagSet and value in tagSet:
         return tagSet[value]
     if value < 0 or (upperLimit and value >= 65536):
-        raise UnknownTagException('Unknown tag %s' % key)
+        raise UnknownTagError('Unknown tag %s' % key)
     tagClass = tagSet._setClass if tagSet else TiffConstant
     return tagClass(value, tagOptions)
 

--- a/tifftools/exceptions.py
+++ b/tifftools/exceptions.py
@@ -1,10 +1,15 @@
-class TifftoolsException(Exception):
+class TifftoolsError(Exception):
     pass
 
 
-class UnknownTagException(TifftoolsException):
+class UnknownTagError(TifftoolsError):
     pass
 
 
-class MustBeBigTiffException(TifftoolsException):
+class MustBeBigTiffError(TifftoolsError):
     pass
+
+
+TifftoolsException = TifftoolsError
+UnknownTagException = UnknownTagError
+MustBeBigTiffException = MustBeBigTiffError


### PR DESCRIPTION
This is the preferred pythonic naming convention.  The old names are retained for backwards compatibility.