### PR TITLE
get_or_create_tag returns a TiffTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Improvements
+- When creating some tags, return a TiffTag rather than TiffConstant (#57)
+
 ## Version 1.2.7
 
 ### Improvements

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -56,7 +56,7 @@ def test_get_or_create_tag():
         40000, tifftools.Tag, datatype=tifftools.Datatype.ASCII
     ).datatype == tifftools.Datatype.ASCII
     assert get_or_create_tag(40000).name == '40000'
-    assert not isinstance(get_or_create_tag(40000), tifftools.TiffTag)
+    assert isinstance(get_or_create_tag(40000), tifftools.TiffTag)
 
 
 def test_get_or_create_tag_limits():

--- a/tifftools/constants.py
+++ b/tifftools/constants.py
@@ -167,7 +167,7 @@ def get_or_create_tag(key, tagSet=None, upperLimit=True, **tagOptions):
         return tagSet[value]
     if value < 0 or (upperLimit and value >= 65536):
         raise UnknownTagError('Unknown tag %s' % key)
-    tagClass = tagSet._setClass if tagSet else TiffConstant
+    tagClass = tagSet._setClass if tagSet else TiffTag
     return tagClass(value, tagOptions)
 
 


### PR DESCRIPTION
Before, it could return a less specific TiffConstant.