### PR TITLE
Stop using pkg_resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Version 1.2.10
+
+### Improvements
+- Don't use pkg_resources for finding version ([#62](../../pull/62))
+
 ## Version 1.2.9
 
 ### Improvements

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ],
     description='Pure python tiff tools to handle all tags and IFDs.',
     install_requires=[
+        'importlib-metadata ; python_version < "3.8"',
     ],
     license='Apache Software License 2.0',
     long_description=readme,

--- a/tifftools/__init__.py
+++ b/tifftools/__init__.py
@@ -1,14 +1,16 @@
 import logging
 
-from pkg_resources import get_distribution
-
 from .commands import main, tiff_concat, tiff_dump, tiff_info, tiff_merge, tiff_set, tiff_split
 from .constants import Datatype, Tag, TiffDatatype, TiffTag
 from .exceptions import (MustBeBigTiffError, MustBeBigTiffException, TifftoolsError,
                          TifftoolsException, UnknownTagError, UnknownTagException)
 from .tifftools import read_tiff, write_tiff
 
-__version__ = get_distribution(__name__).version
+try:
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import version as _importlib_version
+__version__ = _importlib_version(__name__)
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
importlib is significantly faster, which results in speeding up importing the library.