### PR TITLE
Make it easier to add new ifds by not requiring path_or_fobj.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 1.3.3
+
+### Improvements
+- Add optional support for argcomplete ([#68](../../pull/68))
+- Make it easier to add new ifds ([#70](../../pull/70))
+
 ## Version 1.3.1
 
 ### Improvements

--- a/tests/test_write_tiff.py
+++ b/tests/test_write_tiff.py
@@ -170,3 +170,18 @@ def test_write_bad_strip_offset(tmp_path, caplog):
     assert 'from desired offset' in caplog.text
     destinfo = tifftools.read_tiff(destpath)
     assert destinfo['ifds'][0]['tags'][tifftools.Tag.StripOffsets.value]['data'][0] == 0
+
+
+def test_write_new_ifd_without_fobj(tmp_path):
+    path = datastore.fetch('d043-200.tif')
+    info = tifftools.read_tiff(path)
+    del info['ifds'][0]['tags'][tifftools.Tag.EXIFIFD.value]
+    newifdentry = {'datatype': tifftools.Datatype.IFD, 'ifds': [[{'tags': {}}]]}
+    info['ifds'][0]['tags'][tifftools.Tag.EXIFIFD.value] = newifdentry
+    newifd = newifdentry['ifds'][0][0]
+    newifd['tags'][tifftools.constants.EXIFTag.ExposureTime.value] = {
+        'datatype': tifftools.Datatype.FLOAT, 'data': [10]}
+    destpath = tmp_path / 'sample.tiff'
+    tifftools.write_tiff(info, destpath)
+    newinfo = tifftools.read_tiff(destpath)
+    assert len(newinfo['ifds'][0]['tags'][tifftools.Tag.EXIFIFD.value]['ifds'][0][0]['tags']) == 1

--- a/tifftools/path_or_fobj.py
+++ b/tifftools/path_or_fobj.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import contextlib
+import io
 import shutil
 import sys
 import tempfile
@@ -21,10 +22,11 @@ def OpenPathOrFobj(pathOrObj, mode='rb'):
     """
     Given any of a file path, a pathlib Path object, a filelike-object that is
     seekable, a filelike-object that is not seekable, or '-' or None to
-    indicate either stdin or stdout, return a seekable filelike-object.
+    indicate either stdin or stdout, return a seekable filelike-object.  False
+    to return seekable memory buffer.
 
-    :param pathOrObj: one of a file path, pathlib Path, filelike-object, or
-        None or '-'.
+    :param pathOrObj: one of a file path, pathlib Path, filelike-object, None
+        or '-', or False.
     :param mode: the mode to open a path or temporary file as needed.  This
         won't affect a seekable filelike-object.  If '-' or None is specified,
         the presence of 'w' determines if stdout or stdin is opened (always in
@@ -33,7 +35,9 @@ def OpenPathOrFobj(pathOrObj, mode='rb'):
     """
     if pathOrObj == '-' or pathOrObj is None:
         pathOrObj = sys.stdout.buffer if 'w' in mode.lower() else sys.stdin.buffer
-    if not is_filelike_object(pathOrObj):
+    if pathOrObj is False:
+        yield io.BytesIO()
+    elif not is_filelike_object(pathOrObj):
         with open(pathOrObj, mode) as fobj:
             yield fobj
     elif (hasattr(pathOrObj, 'seekable') and pathOrObj.seekable() and

--- a/tifftools/tifftools.py
+++ b/tifftools/tifftools.py
@@ -327,7 +327,7 @@ def write_ifd(dest, bom, bigtiff, ifd, ifdPtr, tagSet=Tag):
     dest.seek(0, os.SEEK_END)
     ifdrecord = struct.pack(bom + ('Q' if bigtiff else 'H'), len(ifd['tags']))
     subifdPtrs = {}
-    with OpenPathOrFobj(ifd['path_or_fobj'], 'rb') as src:
+    with OpenPathOrFobj(ifd.get('path_or_fobj', False), 'rb') as src:
         for tag, taginfo in sorted(ifd['tags'].items()):
             tag = get_or_create_tag(
                 tag, tagSet, **({'datatype': Datatype[taginfo['datatype']]}


### PR DESCRIPTION
The path_or_fobj internal value is only required for ifds if they need to transfer data from an existing tiff file.  If tags are entirely self-contained, this is no longer required to be set.