### PR TITLE
Don't repeat bytes for immediately repeated byte series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Version 1.3.9
+
+### Improvements
+- Don't repeat bytes for immediately repeated byte series ([#82](../../pull/82))
+
 ## Version 1.3.8
 
 ### Improvements

--- a/tests/test_write_tiff.py
+++ b/tests/test_write_tiff.py
@@ -106,7 +106,7 @@ def test_write_bigtiff_with_offset_data(tmp_path):
     info = tifftools.read_tiff(path)
     info['ifds'][0]['tags'][tifftools.Tag.FreeOffsets.value] = {
         'datatype': tifftools.Datatype.LONG,
-        'data': [8] * 256,
+        'data': list(range(8, 8 + 256)),
     }
     info['ifds'][0]['tags'][tifftools.Tag.FreeByteCounts.value] = {
         'datatype': tifftools.Datatype.LONG,
@@ -116,6 +116,23 @@ def test_write_bigtiff_with_offset_data(tmp_path):
     tifftools.write_tiff(info, destpath)
     destinfo = tifftools.read_tiff(destpath)
     assert destinfo['bigtiff'] is True
+
+
+def test_write_bigtiff_with_repeated_offset_data(tmp_path):
+    path = datastore.fetch('hamamatsu.ndpi')
+    info = tifftools.read_tiff(path)
+    info['ifds'][0]['tags'][tifftools.Tag.FreeOffsets.value] = {
+        'datatype': tifftools.Datatype.LONG,
+        'data': [8] * 256,
+    }
+    info['ifds'][0]['tags'][tifftools.Tag.FreeByteCounts.value] = {
+        'datatype': tifftools.Datatype.LONG,
+        'data': [16777216] * 256,
+    }
+    destpath = tmp_path / 'sample.tiff'
+    tifftools.write_tiff(info, destpath)
+    destinfo = tifftools.read_tiff(destpath)
+    assert destinfo['bigtiff'] is False
 
 
 def test_write_bytecount_data(tmp_path):

--- a/tifftools/commands.py
+++ b/tifftools/commands.py
@@ -706,7 +706,7 @@ use 'sample.tiff,1'."""
     # If argcomplete is optionally installed, support bash completion.
     # Compelteion installation will be something like
     #   eval "$(register-python-argcomplete tifftools)"
-    # See argcompelte's documentation.
+    # See argcomplete's documentation.
     try:
         import argcomplete
         argcomplete.autocomplete(mainParser)

--- a/tifftools/tifftools.py
+++ b/tifftools/tifftools.py
@@ -530,10 +530,16 @@ def write_tag_data(dest, src, offsets, lengths, srclen):
     # We preserve the order of the chunks from the original file
     offsetList = sorted([(offset, idx) for idx, offset in enumerate(offsets)])
     olidx = 0
+    lastOffset = lastLength = lastOffsetIdx = None
     while olidx < len(offsetList):
         offset, idx = offsetList[olidx]
         length = lengths[idx]
         if offset and check_offset(srclen, offset, length):
+            if lastOffset == offset and lastLength == length:
+                destOffsets[idx] = destOffsets[lastOffsetIdx]
+                olidx += 1
+                continue
+            lastOffset, lastLength, lastOffsetIdx = offset, length, idx
             src.seek(offset)
             destOffsets[idx] = dest.tell()
             # Group reads when possible; the biggest overhead is in the actual


### PR DESCRIPTION
This allows more compact files that have repeated tiles or strips.